### PR TITLE
Trailing 0 get closest bug fix.

### DIFF
--- a/lib/versionAttribute.js
+++ b/lib/versionAttribute.js
@@ -120,22 +120,24 @@ module.exports = function versionAttributeMain() {
           parentCrumbs = [];
           break;
         }
+
         // To move the base we need parent as the tree at root.
         parent = tree;
         // We also need to specially handle non-existant keys case.
         keys = _.keysIn(parent);
         // Do we actually have keys higher up the tree or equal to the path?
         keyReturn = _.chain(keys)
+        .map(_.parseInt)
         .filter((n) => n <= pathCrumbs[0])
         .value();
         // This a special case of special case.
-        if (keyReturn.length === 1) {
+        if (keyReturn.length === 1 || _.without(_.drop(pathCrumbs, 1), 0).length === 0) {
           // Like Jim Morrison, we need to know if we can get much higher.
           tempKeyReturn = _.filter(keyReturn, (n) => n < pathCrumbs[0]);
           if (tempKeyReturn.length > 0) {
             // Yeah, we can.
             parentCrumbs = [keys[_.findLastKey(keys, (n) => (
-               n <= pathCrumbs[0]
+               n < pathCrumbs[0]
             ))]];
             break;
           }
@@ -198,7 +200,6 @@ module.exports = function versionAttributeMain() {
 
     // We will now try and descend.
     tempPathCrumbs = _.cloneDeep(ascendPathCrumbs);
-
     while (tempPathCrumbs.length !== 0) {
       // keep going until we get a
       tempPathCrumbs = descendPath(ascendPathCrumbs, tree);

--- a/test/version-attribute.js
+++ b/test/version-attribute.js
@@ -173,12 +173,17 @@ module.exports = {
   },
   getPreviousClosestVersion: function getPreviousClosestVersionTest(test) {
     const versionedAttribute = versionAttribute();
-    test.expect(5);
+    test.expect(6);
     // Empty version returns error.
     test.deepEqual(
       versionedAttribute.getPreviousClosestVersion([1, 0, 1], versionedSuperObject),
       [1, 0],
       'Base paths should go down a level'
+    );
+    test.deepEqual(
+      versionedAttribute.getPreviousClosestVersion([2, 0], versionedSuperObject),
+      [1, 0, 1],
+      'Base paths should go up and then down to get next closest.'
     );
     // Empty version returns error.
     test.deepEqual(


### PR DESCRIPTION
Resolves #3 

We had some non int values we were testing for, additionally, basically if the last elements in a version are all 0s (that is it will reduce to an empty array once it is reverse sliced) i.e. [1,0,0] when the first place is removed leaves only [0,0] and if we filter 0s out we have an empty array. In that way we can determine if we had a trailing 0 situation, - that's where we need to look at the parent in a new way, that we previously were only using for single value target versions like [4] or [3]